### PR TITLE
use openssl in /booth.sh to allow https connections

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 # this script is used to boot a Docker container
 
+openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj "/C=US/ST=TN/L=H/O=Cachengo/CN=Cachengo" -keyout key.pem -out cert.pem
+
 flask db upgrade
-exec gunicorn -b :5000 --access-logfile - --error-logfile - sso_example:app
+
+exec gunicorn -b :5000 --access-logfile - --error-logfile - --certfile cert.pem --keyfile key.pem sso_example:app

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-# Also docker build -t sso_example .
+docker build -t sso_example .
 docker network create -d bridge mybridge
 
 docker stop sso
@@ -18,4 +18,4 @@ docker run -d -v /db/index256:/db -e "ANN_INDEX_LENGTH=256" \
 docker run -d --network=mybridge --name=facerec cachengo/facerec:1.0
 
 docker run -d -p 5000:5000 -v /db/sso:/db -e "NN_SEARCH_ADDRESS=nn_search:1323" \
-  -e "FACEREC_ADDRESS=facerec:5000" --network=mybridge --name sso cachengo/sso_example:1.2
+  -e "FACEREC_ADDRESS=facerec:5000" --network=mybridge --name sso sso_example


### PR DESCRIPTION
Allowed server to use https connections. I also made a change in /run.sh to use the local repo of sso_example.